### PR TITLE
fix(Dockerfile): LegacyKeyValueFormat warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN apt update && \
     sed -i -e 's/# it_IT.UTF-8 UTF-8/it_IT.UTF-8 UTF-8/' /etc/locale.gen && \
     dpkg-reconfigure --frontend=noninteractive locales
 
-ENV LANG it_IT.UTF-8
-ENV LC_ALL it_IT.UTF-8
+ENV LANG=it_IT.UTF-8
+ENV LC_ALL=it_IT.UTF-8
 
 COPY requirements.txt .
 RUN pip3 install -r requirements.txt


### PR DESCRIPTION
After building with the command `sudo docker build -t ersubot .` I noticed this warning:
```
 2 warnings found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 9)
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 10)
```
more documentation about: https://docs.docker.com/reference/build-checks/legacy-key-value-format/