### PR TITLE
fix(scraper.py): double sending articles

### DIFF
--- a/module/scraper/scraper.py
+++ b/module/scraper/scraper.py
@@ -178,3 +178,4 @@ def scrape_news(context: CallbackContext) -> None:
     articles.reverse()
 
     scrape_table(articles, context)
+    


### PR DESCRIPTION
I figured out that the function `soup.find_all('article')`  in line 178, listed two times some articles, [here](https://pastes.dev/9uT3RXIWwS) is the output of that function.
I currently have no clue about the reason of this behavior.

I found that `<header class="sow-entry-header">` was exclusively used for articles, [here](https://pastes.dev/ZGdVZqSGYC) is the output of `soup.find_all('header', class_='sow-entry-header')`
I tested this with the latest 10 ERSU articles and it works perfectly.

closes #40